### PR TITLE
Add overall student analysis and persistent data storage

### DIFF
--- a/data/all_students.html
+++ b/data/all_students.html
@@ -1,0 +1,438 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>전체 학생 성적 분석</title>
+  <link rel="stylesheet" href="../style.css" />
+  <style>
+    body { background: #eef2f7; }
+    .summary-container {
+      max-width: 1280px;
+      margin: 30px auto;
+      background: #ffffff;
+      padding: 32px;
+      border-radius: 18px;
+      box-shadow: 0 18px 45px rgba(15, 23, 42, 0.12);
+    }
+    .summary-header {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 16px;
+      margin-bottom: 24px;
+    }
+    .summary-header h1 {
+      margin: 0;
+      font-size: 2.1rem;
+      color: #0f172a;
+      text-align: center;
+    }
+    .summary-links {
+      display: flex;
+      gap: 12px;
+      flex-wrap: wrap;
+      justify-content: center;
+    }
+    .summary-links a {
+      padding: 8px 16px;
+      border-radius: 999px;
+      background: #e8f0fe;
+      color: #0b57d0;
+      font-weight: 600;
+      text-decoration: none;
+      transition: background-color 0.2s ease, color 0.2s ease, transform 0.15s ease;
+    }
+    @media (hover: hover) and (pointer: fine) {
+      .summary-links a:hover {
+        background: #d2e3fc;
+        color: #0840a3;
+        transform: translateY(-1px);
+      }
+    }
+    .summary-links a:focus { outline: 2px solid #0b57d0; outline-offset: 2px; }
+    .summary-description {
+      margin: 0 auto 18px;
+      max-width: 760px;
+      text-align: center;
+      color: #475569;
+      line-height: 1.6;
+      font-size: 1rem;
+    }
+    .analysis-notice {
+      margin-bottom: 20px;
+      padding: 14px 18px;
+      border-radius: 10px;
+      background: #f1f5f9;
+      color: #1e293b;
+      font-weight: 600;
+    }
+    .analysis-notice.warning {
+      background: #fdecea;
+      color: #b71c1c;
+      border: 1px solid #f5c6cb;
+    }
+    .table-wrapper { overflow-x: auto; }
+    table#analysisTable { width: 100%; border-collapse: collapse; margin-top: 0; }
+    #analysisTable th, #analysisTable td {
+      padding: 12px 10px;
+      border: 1px solid #e2e8f0;
+      text-align: center;
+      font-size: 0.95rem;
+    }
+    #analysisTable thead th {
+      background: #0b57d0;
+      color: #ffffff;
+      font-size: 1rem;
+      position: sticky;
+      top: 0;
+      z-index: 1;
+    }
+    #analysisTable tbody tr:nth-child(even) { background: #f8fbff; }
+    #analysisTable tbody tr:hover { background: #eef6ff; }
+    .subject-grade {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 4px;
+      min-width: 120px;
+    }
+    .subject-grade .score { font-weight: 600; color: #1f2937; }
+    .grade-tag {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      min-width: 52px;
+      padding: 2px 12px;
+      border-radius: 999px;
+      font-size: 0.85rem;
+      font-weight: 700;
+      color: #ffffff;
+      letter-spacing: 0.01em;
+    }
+    .grade-tag.is-1 { background: #c62828; }
+    .grade-tag.is-2 { background: #ef6c00; }
+    .grade-tag.is-3 { background: #2e7d32; }
+    .grade-tag.is-4 { background: #1565c0; }
+    .grade-tag.is-5 { background: #6a1b9a; }
+    .rank-cell { font-weight: 700; color: #0f172a; }
+    .summary-note {
+      margin-top: 18px;
+      color: #64748b;
+      font-size: 0.9rem;
+      line-height: 1.5;
+    }
+    @media (max-width: 768px) {
+      .summary-container { margin: 16px; padding: 24px 18px; }
+      .subject-grade { min-width: 100px; }
+    }
+  </style>
+</head>
+<body>
+  <div class="summary-container">
+    <header class="summary-header">
+      <h1>전체 학생 성적 분석</h1>
+      <div class="summary-links">
+        <a href="../index.html">메인으로</a>
+        <a href="grade_cal.html">등급계산기</a>
+      </div>
+    </header>
+    <p class="summary-description">
+      업로드한 엑셀 데이터를 기반으로 학생들의 과목별 평균 점수와 등급, 전체 등수를 계산해 보여줍니다.
+      데이터가 없다면 먼저 메인 페이지에서 엑셀 파일을 업로드하세요.
+    </p>
+    <div id="analysisNotice" class="analysis-notice"></div>
+    <div id="analysisTableWrapper" class="table-wrapper" style="display:none;">
+      <table id="analysisTable">
+        <thead></thead>
+        <tbody></tbody>
+      </table>
+    </div>
+    <p class="summary-note">
+      ※ 과목별 등급은 전체 학생의 해당 과목 평균 점수 순위를 기준으로 1~5등급(10% / 24% / 32% / 24% / 10%)을 부여하며, 동점자는 같은 등급을 받습니다.
+    </p>
+  </div>
+  <script>
+    const STORAGE_KEY = 'gradesApp.studentDataset';
+    const FALLBACK_SUBJECTS = ['공통국어','공통수학','공통영어','한국사','통합사회','통합과학'];
+    const GRADE_CONFIG = [
+      { label: '1등급', percent: 10 },
+      { label: '2등급', percent: 24 },
+      { label: '3등급', percent: 32 },
+      { label: '4등급', percent: 24 },
+      { label: '5등급', percent: 10 }
+    ];
+
+    const noticeEl = document.getElementById('analysisNotice');
+    const tableWrapper = document.getElementById('analysisTableWrapper');
+    const tableHead = document.querySelector('#analysisTable thead');
+    const tableBody = document.querySelector('#analysisTable tbody');
+
+    init();
+
+    function init() {
+      const data = loadData();
+      if (!data) {
+        showWarning('저장된 학생 데이터가 없습니다. 메인 페이지에서 엑셀 파일을 업로드한 뒤 다시 확인해주세요.');
+        return;
+      }
+
+      const { subjects, students } = data;
+      const entries = Object.entries(students || {});
+      if (!entries.length) {
+        showWarning('분석할 학생 데이터가 비어 있습니다. 엑셀 파일의 내용을 확인해주세요.');
+        return;
+      }
+
+      renderTable(subjects, entries);
+    }
+
+    function loadData() {
+      if (typeof window === 'undefined' || !window.localStorage) {
+        return null;
+      }
+      try {
+        const raw = window.localStorage.getItem(STORAGE_KEY);
+        if (!raw) return null;
+        const parsed = JSON.parse(raw);
+        if (!parsed || typeof parsed !== 'object' || !parsed.students) return null;
+        const subjects = Array.isArray(parsed.subjects) && parsed.subjects.length ? parsed.subjects : FALLBACK_SUBJECTS;
+        return { subjects, students: parsed.students };
+      } catch (err) {
+        console.error('데이터를 불러오는 중 오류가 발생했습니다.', err);
+        return null;
+      }
+    }
+
+    function showWarning(message) {
+      noticeEl.textContent = message;
+      noticeEl.classList.add('warning');
+      tableWrapper.style.display = 'none';
+    }
+
+    function renderTable(subjects, entries) {
+      const summaries = entries.map(([name, info]) => buildStudentSummary(name, info, subjects));
+      const overallRanks = computeOverallRanks(summaries);
+      const subjectGrades = computeSubjectGrades(subjects, summaries);
+      const collator = new Intl.Collator('ko');
+
+      const sorted = summaries.slice().sort((a, b) => {
+        const rankA = rankValue(overallRanks[a.name]);
+        const rankB = rankValue(overallRanks[b.name]);
+        if (rankA === rankB) {
+          return collator.compare(a.name, b.name);
+        }
+        return rankA - rankB;
+      });
+
+      buildTableHead(subjects);
+      tableBody.innerHTML = '';
+
+      sorted.forEach(summary => {
+        const tr = document.createElement('tr');
+        const rank = overallRanks[summary.name];
+        const numberCell = summary.number ? summary.number : '-';
+        const sumCell = Number.isFinite(summary.totalSum) ? summary.totalSum.toFixed(1) : '-';
+        const avgCell = Number.isFinite(summary.average) ? summary.average.toFixed(1) : '-';
+
+        const subjectCells = subjects.map((_, idx) => createSubjectCell(summary, idx, subjectGrades));
+        tr.innerHTML = `
+          <td>${numberCell}</td>
+          <td>${summary.name}</td>
+          <td>${sumCell}</td>
+          <td>${avgCell}</td>
+          ${subjectCells.join('')}
+          <td class="rank-cell">${typeof rank === 'number' ? `${rank}위` : '-'}</td>
+        `;
+        tableBody.appendChild(tr);
+      });
+
+      noticeEl.classList.remove('warning');
+      noticeEl.textContent = `총 ${sorted.length}명의 학생 데이터를 분석했습니다.`;
+      tableWrapper.style.display = '';
+    }
+
+    function buildStudentSummary(name, info, subjects) {
+      const subjectAverages = subjects.map((_, idx) => computeSubjectAverage(info, idx));
+      const validScores = subjectAverages.filter(score => Number.isFinite(score));
+      const totalSum = validScores.length ? validScores.reduce((sum, value) => sum + value, 0) : null;
+      const average = validScores.length ? totalSum / validScores.length : null;
+      return {
+        name,
+        number: typeof info.number === 'number' ? String(info.number) : (info.number || ''),
+        subjectAverages,
+        totalSum,
+        average
+      };
+    }
+
+    function computeSubjectAverage(info, index) {
+      const values = [];
+      addIfValid(values, info.semester1, index);
+      addIfValid(values, info.semester2, index);
+      addIfValid(values, info.semester3, index);
+      if (!values.length) return null;
+      const sum = values.reduce((acc, cur) => acc + cur, 0);
+      return sum / values.length;
+    }
+
+    function addIfValid(target, term, index) {
+      if (!Array.isArray(term)) return;
+      const value = term[index];
+      if (typeof value === 'number' && Number.isFinite(value)) {
+        target.push(value);
+      }
+    }
+
+    function computeOverallRanks(summaries) {
+      const ranked = {};
+      const sorted = summaries.slice().sort((a, b) => {
+        const avgA = Number.isFinite(a.average) ? a.average : -Infinity;
+        const avgB = Number.isFinite(b.average) ? b.average : -Infinity;
+        return avgB - avgA;
+      });
+
+      let currentRank = 0;
+      let previousScore = null;
+      sorted.forEach((summary, index) => {
+        if (!Number.isFinite(summary.average)) {
+          ranked[summary.name] = '-';
+          return;
+        }
+        const normalized = Number(summary.average.toFixed(4));
+        if (previousScore !== null && Math.abs(normalized - previousScore) < 1e-6) {
+          ranked[summary.name] = currentRank;
+        } else {
+          currentRank = index + 1;
+          ranked[summary.name] = currentRank;
+          previousScore = normalized;
+        }
+      });
+
+      summaries.forEach(summary => {
+        if (!Number.isFinite(summary.average)) {
+          ranked[summary.name] = '-';
+        }
+      });
+
+      return ranked;
+    }
+
+    function computeSubjectGrades(subjects, summaries) {
+      const gradeMap = {};
+      summaries.forEach(summary => {
+        gradeMap[summary.name] = Array(subjects.length).fill('-');
+      });
+
+      subjects.forEach((_, idx) => {
+        const subjectScores = summaries
+          .map(summary => ({ name: summary.name, score: summary.subjectAverages[idx] }))
+          .filter(entry => Number.isFinite(entry.score))
+          .sort((a, b) => b.score - a.score);
+
+        if (!subjectScores.length) {
+          return;
+        }
+
+        const boundaries = buildGradeBoundaries(subjectScores.length);
+        subjectScores.forEach((entry, position) => {
+          let grade = gradeForRank(position + 1, boundaries);
+          if (position > 0) {
+            const previous = subjectScores[position - 1];
+            if (Math.abs(entry.score - previous.score) < 1e-6) {
+              grade = previous.assignedGrade;
+            }
+          }
+          entry.assignedGrade = grade;
+          gradeMap[entry.name][idx] = grade;
+        });
+      });
+
+      return gradeMap;
+    }
+
+    function buildGradeBoundaries(total) {
+      const slots = [];
+      let running = 0;
+      let previousCumulative = 0;
+
+      GRADE_CONFIG.forEach((config, index) => {
+        running += total * (config.percent / 100);
+        let cumulative = index === GRADE_CONFIG.length - 1 ? total : Math.round(running);
+        cumulative = Math.min(Math.max(cumulative, previousCumulative), total);
+        const count = cumulative - previousCumulative;
+        slots.push({ grade: config.label, count });
+        previousCumulative = cumulative;
+      });
+
+      const assignedTotal = slots.reduce((sum, slot) => sum + slot.count, 0);
+      if (assignedTotal < total && slots.length) {
+        slots[slots.length - 1].count += total - assignedTotal;
+      }
+
+      const boundaries = [];
+      let cumulative = 0;
+      slots.forEach(slot => {
+        if (slot.count <= 0) return;
+        cumulative += slot.count;
+        boundaries.push({ grade: slot.grade, maxRank: cumulative });
+      });
+
+      if (!boundaries.length) {
+        boundaries.push({ grade: GRADE_CONFIG[GRADE_CONFIG.length - 1].label, maxRank: total });
+      }
+
+      return boundaries;
+    }
+
+    function gradeForRank(rank, boundaries) {
+      for (const boundary of boundaries) {
+        if (rank <= boundary.maxRank) {
+          return boundary.grade;
+        }
+      }
+      return boundaries.length ? boundaries[boundaries.length - 1].grade : '-';
+    }
+
+    function createSubjectCell(summary, index, gradeMap) {
+      const average = summary.subjectAverages[index];
+      const grade = gradeMap[summary.name]?.[index] ?? '-';
+      const parts = [];
+      if (Number.isFinite(average)) {
+        parts.push(`<span class="score">${average.toFixed(1)}점</span>`);
+      }
+      if (grade !== '-') {
+        parts.push(`<span class="grade-tag ${gradeBadgeClass(grade)}">${grade}</span>`);
+      }
+      if (!parts.length) {
+        return '<td class="subject-grade">-</td>';
+      }
+      return `<td class="subject-grade">${parts.join('')}</td>`;
+    }
+
+    function gradeBadgeClass(grade) {
+      const match = /^([1-5])/.exec(grade);
+      if (!match) return '';
+      return `is-${match[1]}`;
+    }
+
+    function buildTableHead(subjects) {
+      const headerRow = document.createElement('tr');
+      headerRow.innerHTML = `
+        <th>학번</th>
+        <th>이름</th>
+        <th>합계</th>
+        <th>평균</th>
+        ${subjects.map(subject => `<th>${subject} 등급</th>`).join('')}
+        <th>전체 등수</th>
+      `;
+      tableHead.innerHTML = '';
+      tableHead.appendChild(headerRow);
+    }
+
+    function rankValue(rank) {
+      return typeof rank === 'number' ? rank : Number.POSITIVE_INFINITY;
+    }
+  </script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -12,13 +12,17 @@
 <body>
   <div class="container">
     <h1>📊 학생별 성적 추이 분석 시스템</h1>
+    <div class="utility-links">
+      <a href="data/grade_cal.html" class="utility-link">등급계산기</a>
+      <a href="data/all_students.html" class="utility-link">전체학생 분석</a>
+    </div>
 
     <div class="search-section">
       <div class="search-box">
         <label for="studentName">학생 이름:</label>
         <input type="text" id="studentName" placeholder="엑셀 업로드 후 사용 가능" disabled />
         <button id="btnSearch" onclick="searchStudent()" disabled>검색</button>
-        <button id="btnClear" onclick="clearSearch()" disabled>초기화</button>
+        <button id="btnClear" onclick="resetApplication()" disabled>초기화</button>
       </div>
 
       <!-- 업로드 / 다운로드 -->
@@ -38,7 +42,7 @@
             <span id="displayName"></span>
           </div>
           <div class="info-item">
-            <span class="info-label">번호:</span>
+            <span class="info-label">학번:</span>
             <span id="displayNumber"></span>
           </div>
         </div>
@@ -106,24 +110,39 @@
 
   <script>
     const SUBJECTS = ['공통국어','공통수학','공통영어','한국사','통합사회','통합과학'];
+    const STORAGE_KEY = 'gradesApp.studentDataset';
+    const STORAGE_AVAILABLE = (() => {
+      try {
+        const testKey = '__grades_app_test__';
+        window.localStorage.setItem(testKey, '1');
+        window.localStorage.removeItem(testKey);
+        return true;
+      } catch (err) {
+        console.warn('로컬 저장소를 사용할 수 없어 데이터가 새로고침 시 유지되지 않습니다.', err);
+        return false;
+      }
+    })();
 
     document.getElementById('btnTemplate').addEventListener('click', downloadTemplate);
 
-    // 시작은 빈 데이터 / 미로드 상태
     let studentData = {};
     let dataLoaded = false;
     let charts = {};
 
-    // === XLSX Export ===
+    const hintElement = document.querySelector('.hint');
+    const defaultHintText = hintElement ? hintElement.textContent : '';
+
+    loadPersistedData();
+
     function downloadTemplate(evt) {
       if (evt) evt.preventDefault();
 
-      const headers = ['이름','번호'];
+      const headers = ['이름','학번'];
       ['S1','S2','S3'].forEach(term => {
         SUBJECTS.forEach(subject => headers.push(`${term}_${subject}`));
       });
 
-      const sampleStudent = ['홍길동','101'];
+      const sampleStudent = ['홍길동','2024001'];
       const sampleScores = [
         [92, 88, 94, 85, 90, 93],
         [95, 91, 96, 88, 92, 95],
@@ -131,7 +150,7 @@
       ].flat();
       sampleStudent.push(...sampleScores);
 
-      const blankRow = ['김철수','102'];
+      const blankRow = ['김철수','2024002'];
       blankRow.push(...Array(SUBJECTS.length * 3).fill(''));
 
       const worksheet = XLSX.utils.aoa_to_sheet([
@@ -149,9 +168,9 @@
       if (!dataLoaded) { alert('먼저 데이터를 업로드하세요.'); return; }
       const rows = [];
       for (const [name, info] of Object.entries(studentData)) {
-        const r = {
+        const row = {
           '이름': name,
-          '번호': info.number ?? '',
+          '학번': info.number ?? '',
           'S1_공통국어': info.semester1?.[0] ?? '',
           'S1_공통수학': info.semester1?.[1] ?? '',
           'S1_공통영어': info.semester1?.[2] ?? '',
@@ -171,15 +190,14 @@
           'S3_통합사회': info.semester3?.[4] ?? '',
           'S3_통합과학': info.semester3?.[5] ?? ''
         };
-        rows.push(r);
+        rows.push(row);
       }
-      const ws = XLSX.utils.json_to_sheet(rows);
-      const wb = XLSX.utils.book_new();
-      XLSX.utils.book_append_sheet(wb, ws, 'Scores');
-      XLSX.writeFile(wb, '학생성적_데이터셋.xlsx');
+      const worksheet = XLSX.utils.json_to_sheet(rows);
+      const workbook = XLSX.utils.book_new();
+      XLSX.utils.book_append_sheet(workbook, worksheet, 'Scores');
+      XLSX.writeFile(workbook, '학생성적_데이터셋.xlsx');
     }
 
-    // === XLSX Import ===
     function uploadXLSX(evt) {
       const file = evt.target.files?.[0];
       if (!file) return;
@@ -195,29 +213,19 @@
 
           const newData = {};
           rows.forEach(row => {
-            const name = String(row['이름'] ?? '').trim();
+            const name = extractText(row, ['이름','름']);
             if (!name) return;
-            const number = Number(row['번호'] ?? 0) || 0;
+            const number = extractText(row, ['학번','번호']);
 
-            const s1 = [
-              toNum(row['S1_공통국어']), toNum(row['S1_공통수학']), toNum(row['S1_공통영어']),
-              toNum(row['S1_한국사']),   toNum(row['S1_통합사회']), toNum(row['S1_통합과학'])
-            ];
-            const s2 = [
-              toNum(row['S2_공통국어']), toNum(row['S2_공통수학']), toNum(row['S2_공통영어']),
-              toNum(row['S2_한국사']),   toNum(row['S2_통합사회']), toNum(row['S2_통합과학'])
-            ];
-            const s3 = [
-              toNum(row['S3_공통국어']), toNum(row['S3_공통수학']), toNum(row['S3_공통영어']),
-              toNum(row['S3_한국사']),   toNum(row['S3_통합사회']), toNum(row['S3_통합과학'])
-            ];
+            const s1 = parseTermScores(row, 'S1');
+            const s2 = parseTermScores(row, 'S2');
+            const s3 = parseTermScores(row, 'S3');
 
-            const valid = arr => arr.some(v => v !== '' && !isNaN(v));
             newData[name] = {
               number,
-              semester1: valid(s1) ? s1.map(n => (isNaN(n)?0:n)) : Array(SUBJECTS.length).fill(0),
-              semester2: valid(s2) ? s2.map(n => (isNaN(n)?0:n)) : Array(SUBJECTS.length).fill(0),
-              semester3: valid(s3) ? s3.map(n => (isNaN(n)?0:n)) : []
+              semester1: hasValidScores(s1) ? s1 : Array(SUBJECTS.length).fill(null),
+              semester2: hasValidScores(s2) ? s2 : Array(SUBJECTS.length).fill(null),
+              semester3: hasValidScores(s3) ? s3 : []
             };
           });
 
@@ -230,9 +238,9 @@
           studentData = newData;
           dataLoaded = true;
           enableUIAfterLoad();
+          persistData();
           alert('엑셀 데이터가 성공적으로 업로드되었습니다.');
 
-          // 현재 표시 중인 학생이 있으면 새 데이터 기준으로 갱신
           const current = document.getElementById('studentName').value.trim();
           if (current && studentData[current]) searchStudent();
 
@@ -248,13 +256,34 @@
       reader.readAsArrayBuffer(file);
     }
 
+    function parseTermScores(row, prefix) {
+      return SUBJECTS.map(subject => {
+        const key = `${prefix}_${subject}`;
+        const value = toNum(row[key]);
+        return value === '' ? null : value;
+      });
+    }
+
+    function extractText(row, keys) {
+      for (const key of keys) {
+        if (key in row && row[key] !== undefined && row[key] !== null) {
+          const value = String(row[key]).trim();
+          if (value) return value;
+        }
+      }
+      return '';
+    }
+
+    function hasValidScores(scores) {
+      if (!Array.isArray(scores)) return false;
+      return scores.some(score => typeof score === 'number' && !Number.isNaN(score));
+    }
+
     function enableUIAfterLoad() {
-      // 검색/초기화
       document.getElementById('studentName').disabled = false;
       document.getElementById('btnSearch').disabled = false;
       document.getElementById('btnClear').disabled = false;
 
-      // 추가 입력
       document.getElementById('addStudentName').disabled = false;
       document.getElementById('addKorean').disabled = false;
       document.getElementById('addMath').disabled = false;
@@ -264,17 +293,91 @@
       document.getElementById('addScience').disabled = false;
       document.getElementById('btnAdd').disabled = false;
 
-      // 다운로드
-      document.getElementById('btnDownload').disabled = false;
+      document.getElementById('btnDownload').disabled = Object.keys(studentData).length === 0;
 
-      // 힌트 변경
       document.getElementById('studentName').placeholder = '이름을 입력하세요';
       document.getElementById('addStudentName').placeholder = '이름 입력';
+
+      if (hintElement) {
+        hintElement.textContent = '데이터가 로드되었습니다. 학생 이름을 입력해 검색하세요.';
+      }
     }
 
-    function toNum(v) {
-      const n = Number(v);
-      return isNaN(n) ? '' : n;
+    function disableUIAfterReset() {
+      document.getElementById('studentName').disabled = true;
+      document.getElementById('btnSearch').disabled = true;
+      document.getElementById('btnClear').disabled = true;
+
+      document.getElementById('addStudentName').disabled = true;
+      document.getElementById('addKorean').disabled = true;
+      document.getElementById('addMath').disabled = true;
+      document.getElementById('addEnglish').disabled = true;
+      document.getElementById('addHistory').disabled = true;
+      document.getElementById('addSocial').disabled = true;
+      document.getElementById('addScience').disabled = true;
+      document.getElementById('btnAdd').disabled = true;
+
+      document.getElementById('btnDownload').disabled = true;
+
+      document.getElementById('studentName').placeholder = '엑셀 업로드 후 사용 가능';
+      document.getElementById('addStudentName').placeholder = '엑셀 업로드 후 사용 가능';
+
+      if (hintElement) {
+        hintElement.textContent = defaultHintText;
+      }
+    }
+
+    function persistData() {
+      if (!STORAGE_AVAILABLE) return;
+      try {
+        const payload = { version: 1, subjects: SUBJECTS, students: studentData };
+        window.localStorage.setItem(STORAGE_KEY, JSON.stringify(payload));
+      } catch (err) {
+        console.warn('데이터를 저장하는 중 문제가 발생했습니다.', err);
+      }
+    }
+
+    function clearPersistedData() {
+      if (!STORAGE_AVAILABLE) return;
+      try {
+        window.localStorage.removeItem(STORAGE_KEY);
+      } catch (err) {
+        console.warn('저장된 데이터를 삭제하는 중 문제가 발생했습니다.', err);
+      }
+    }
+
+    function loadPersistedData() {
+      if (!STORAGE_AVAILABLE) return;
+      try {
+        const raw = window.localStorage.getItem(STORAGE_KEY);
+        if (!raw) return;
+        const parsed = JSON.parse(raw);
+        if (!parsed || typeof parsed !== 'object' || !parsed.students) return;
+
+        studentData = parsed.students;
+        dataLoaded = Object.keys(studentData).length > 0;
+
+        if (dataLoaded) {
+          enableUIAfterLoad();
+          if (hintElement) {
+            hintElement.textContent = '이전에 저장된 데이터를 불러왔습니다. 학생 이름을 검색해 확인하세요.';
+          }
+        }
+      } catch (err) {
+        console.warn('저장된 데이터를 불러오는 중 오류가 발생했습니다.', err);
+      }
+    }
+
+    function toNum(value) {
+      if (value === null || value === undefined) return '';
+      if (typeof value === 'string') {
+        const trimmed = value.trim();
+        if (trimmed === '') return '';
+        const parsed = Number(trimmed);
+        return Number.isNaN(parsed) ? '' : parsed;
+      }
+      const parsed = Number(value);
+      return Number.isNaN(parsed) ? '' : parsed;
     }
 
     function searchStudent() {
@@ -286,19 +389,26 @@
       const chartsSection = document.getElementById('chartsSection');
       const dataTable = document.getElementById('dataTable');
 
-      errorMsg.style.display = 'none'; errorMsg.textContent = '';
-      if (!searchName) { errorMsg.textContent = '학생 이름을 입력해주세요.'; errorMsg.style.display = 'block'; return; }
+      errorMsg.style.display = 'none';
+      errorMsg.textContent = '';
+      if (!searchName) {
+        errorMsg.textContent = '학생 이름을 입력해주세요.';
+        errorMsg.style.display = 'block';
+        return;
+      }
 
       const student = studentData[searchName];
       if (!student) {
         errorMsg.textContent = `'${searchName}' 학생을 찾을 수 없습니다. 정확한 이름을 입력해주세요.`;
         errorMsg.style.display = 'block';
-        studentInfo.classList.remove('active'); chartsSection.style.display = 'none'; dataTable.style.display = 'none';
+        studentInfo.classList.remove('active');
+        chartsSection.style.display = 'none';
+        dataTable.style.display = 'none';
         return;
       }
 
       document.getElementById('displayName').textContent = searchName;
-      document.getElementById('displayNumber').textContent = student.number ?? '';
+      document.getElementById('displayNumber').textContent = student.number ? student.number : '-';
       studentInfo.classList.add('active');
       chartsSection.style.display = 'grid';
       dataTable.style.display = 'block';
@@ -308,13 +418,19 @@
 
     function createCharts(name, student) {
       const chartIds = ['koreanChart','mathChart','englishChart','historyChart','socialChart','scienceChart'];
-      const labels = ['1회','2회']; if (student.semester3.length > 0) labels.push('3회');
+      const hasThird = hasValidScores(student.semester3 || []);
+      const labels = hasThird ? ['1회','2회','3회'] : ['1회','2회'];
 
       chartIds.forEach((chartId, index) => {
         if (charts[chartId]) charts[chartId].destroy();
         const ctx = document.getElementById(chartId).getContext('2d');
-        const data = [student.semester1?.[index] ?? 0, student.semester2?.[index] ?? 0];
-        if (student.semester3.length > 0) data.push(student.semester3?.[index] ?? 0);
+        const dataset = [
+          sanitizeScore(student.semester1?.[index]),
+          sanitizeScore(student.semester2?.[index])
+        ];
+        if (hasThird) {
+          dataset.push(sanitizeScore(student.semester3?.[index]));
+        }
 
         charts[chartId] = new Chart(ctx, {
           type: 'line',
@@ -322,17 +438,31 @@
             labels,
             datasets: [{
               label: SUBJECTS[index],
-              data,
+              data: dataset,
               borderColor: getChartColor(index),
               backgroundColor: getChartColor(index, 0.2),
-              borderWidth: 2, tension: 0.1, pointRadius: 5, pointHoverRadius: 7
+              borderWidth: 2,
+              tension: 0.1,
+              pointRadius: 5,
+              pointHoverRadius: 7
             }]
           },
           options: {
-            responsive: true, maintainAspectRatio: true,
-            plugins: { legend: { display: false }, tooltip: {
-              callbacks: { label: (c) => `${c.parsed.y.toFixed(1)}점` }
-            }},
+            responsive: true,
+            maintainAspectRatio: true,
+            plugins: {
+              legend: { display: false },
+              tooltip: {
+                callbacks: {
+                  label: (context) => {
+                    if (context.parsed.y === null || context.parsed.y === undefined) {
+                      return '점수 없음';
+                    }
+                    return `${context.parsed.y.toFixed(1)}점`;
+                  }
+                }
+              }
+            },
             scales: {
               y: { beginAtZero: true, max: 100, ticks: { stepSize: 20 }, title: { display: true, text: '점수' } },
               x: { title: { display: true, text: '고사 차시' } }
@@ -340,6 +470,10 @@
           }
         });
       });
+    }
+
+    function sanitizeScore(value) {
+      return (typeof value === 'number' && Number.isFinite(value)) ? value : null;
     }
 
     function getChartColor(index, alpha = 1) {
@@ -358,30 +492,86 @@
       const tbody = document.getElementById('scoresBody');
       tbody.innerHTML = '';
 
-      const row1 = tbody.insertRow();
-      row1.insertCell(0).textContent = '1회';
-      (student.semester1 || []).forEach(s => row1.insertCell().textContent = Number(s).toFixed(1));
-      row1.insertCell().textContent = ((student.semester1 || []).reduce((a,b)=>a+Number(b||0),0)/SUBJECTS.length).toFixed(1);
+      const createRow = (label, scores) => {
+        const row = tbody.insertRow();
+        row.insertCell(0).textContent = label;
+        for (let i = 0; i < SUBJECTS.length; i++) {
+          row.insertCell().textContent = formatScore(Array.isArray(scores) ? scores[i] : null);
+        }
+        row.insertCell().textContent = calculateAverage(scores);
+      };
 
-      const row2 = tbody.insertRow();
-      row2.insertCell(0).textContent = '2회';
-      (student.semester2 || []).forEach(s => row2.insertCell().textContent = Number(s).toFixed(1));
-      row2.insertCell().textContent = ((student.semester2 || []).reduce((a,b)=>a+Number(b||0),0)/SUBJECTS.length).toFixed(1);
-
-      if ((student.semester3 || []).length > 0) {
-        const row3 = tbody.insertRow();
-        row3.insertCell(0).textContent = '3회';
-        student.semester3.forEach(s => row3.insertCell().textContent = Number(s).toFixed(1));
-        row3.insertCell().textContent = ((student.semester3 || []).reduce((a,b)=>a+Number(b||0),0)/SUBJECTS.length).toFixed(1);
+      createRow('1회', student.semester1);
+      createRow('2회', student.semester2);
+      if (hasValidScores(student.semester3 || [])) {
+        createRow('3회', student.semester3);
       }
     }
 
-    function clearSearch() {
+    function formatScore(value) {
+      return (typeof value === 'number' && Number.isFinite(value)) ? value.toFixed(1) : '-';
+    }
+
+    function calculateAverage(scores) {
+      if (!Array.isArray(scores)) return '-';
+      const valid = scores.filter(score => typeof score === 'number' && Number.isFinite(score));
+      if (valid.length === 0) return '-';
+      const average = valid.reduce((sum, score) => sum + score, 0) / valid.length;
+      return average.toFixed(1);
+    }
+
+    function resetApplication() {
+      const hasStoredData = STORAGE_AVAILABLE && !!window.localStorage.getItem(STORAGE_KEY);
+      if (!dataLoaded && !hasStoredData) {
+        document.getElementById('studentName').value = '';
+        const errorMsg = document.getElementById('errorMessage');
+        errorMsg.style.display = 'none';
+        errorMsg.textContent = '';
+        document.getElementById('studentInfo').classList.remove('active');
+        document.getElementById('chartsSection').style.display = 'none';
+        document.getElementById('dataTable').style.display = 'none';
+        return;
+      }
+
+      if (!confirm('업로드한 모든 데이터를 삭제하고 초기 상태로 되돌리시겠습니까?')) {
+        return;
+      }
+
+      clearPersistedData();
+      destroyCharts();
+      studentData = {};
+      dataLoaded = false;
+
       document.getElementById('studentName').value = '';
-      document.getElementById('errorMessage').style.display = 'none';
+      document.getElementById('addStudentName').value = '';
+      ['addKorean','addMath','addEnglish','addHistory','addSocial','addScience'].forEach(id => {
+        document.getElementById(id).value = '';
+      });
+
+      const errorMsg = document.getElementById('errorMessage');
+      errorMsg.style.display = 'none';
+      errorMsg.textContent = '';
+
       document.getElementById('studentInfo').classList.remove('active');
       document.getElementById('chartsSection').style.display = 'none';
       document.getElementById('dataTable').style.display = 'none';
+      document.getElementById('displayName').textContent = '';
+      document.getElementById('displayNumber').textContent = '';
+      document.getElementById('scoresBody').innerHTML = '';
+      document.getElementById('xlsxInput').value = '';
+
+      disableUIAfterReset();
+
+      alert('모든 데이터가 초기화되었습니다.');
+    }
+
+    function destroyCharts() {
+      Object.values(charts).forEach(chart => {
+        if (chart && typeof chart.destroy === 'function') {
+          chart.destroy();
+        }
+      });
+      charts = {};
     }
 
     function addThirdSemester() {
@@ -390,33 +580,25 @@
       const name = document.getElementById('addStudentName').value.trim();
       if (!name || !studentData[name]) { alert('유효한 학생 이름을 입력해주세요.'); return; }
 
-      const scores = [
-        parseFloat(document.getElementById('addKorean').value),
-        parseFloat(document.getElementById('addMath').value),
-        parseFloat(document.getElementById('addEnglish').value),
-        parseFloat(document.getElementById('addHistory').value),
-        parseFloat(document.getElementById('addSocial').value),
-        parseFloat(document.getElementById('addScience').value)
-      ];
+      const fields = ['addKorean','addMath','addEnglish','addHistory','addSocial','addScience'];
+      const scores = fields.map(id => parseFloat(document.getElementById(id).value));
 
-      if (scores.some(s => isNaN(s))) { alert('모든 과목의 점수를 입력해주세요.'); return; }
+      if (scores.some(score => Number.isNaN(score))) {
+        alert('모든 과목의 점수를 입력해주세요.');
+        return;
+      }
 
       studentData[name].semester3 = scores;
+      persistData();
       alert(`${name} 학생의 3회 고사 성적이 추가되었습니다.`);
 
       document.getElementById('addStudentName').value = '';
-      document.getElementById('addKorean').value = '';
-      document.getElementById('addMath').value = '';
-      document.getElementById('addEnglish').value = '';
-      document.getElementById('addHistory').value = '';
-      document.getElementById('addSocial').value = '';
-      document.getElementById('addScience').value = '';
+      fields.forEach(id => document.getElementById(id).value = '');
 
       const currentSearchName = document.getElementById('studentName').value.trim();
       if (currentSearchName === name) searchStudent();
     }
 
-    // Enter로 검색
     document.getElementById('studentName').addEventListener('keypress', function(e) {
       if (e.key === 'Enter') searchStudent();
     });

--- a/style.css
+++ b/style.css
@@ -1,6 +1,19 @@
 body { font-family: 'Malgun Gothic', sans-serif; margin: 20px; background-color: #f5f5f5; }
 .container { max-width: 1400px; margin: 0 auto; background-color: white; padding: 20px; border-radius: 10px; box-shadow: 0 2px 10px rgba(0,0,0,0.1); }
 h1 { color: #333; text-align: center; margin-bottom: 30px; }
+.utility-links { display: flex; justify-content: center; gap: 12px; flex-wrap: wrap; margin: -10px 0 20px; }
+.utility-link {
+  display: inline-flex; align-items: center; justify-content: center;
+  padding: 8px 16px; border-radius: 999px; font-weight: 600; font-size: 15px;
+  color: #0c47a1; background-color: #e8f0fe; text-decoration: none;
+  transition: background-color 0.2s ease, color 0.2s ease, transform 0.15s ease;
+}
+@media (hover: hover) and (pointer: fine) {
+  .utility-link:hover {
+    background-color: #d2e3fc; color: #0b3d91; transform: translateY(-1px);
+  }
+}
+.utility-link:focus { outline: 2px solid #0b57d0; outline-offset: 2px; }
 .search-section { background-color: #f9f9f9; padding: 20px; border-radius: 8px; margin-bottom: 30px; }
 .search-box { display: flex; gap: 10px; align-items: center; margin-bottom: 15px; flex-wrap: wrap; }
 input[type="text"] { padding: 10px; border: 2px solid #ddd; border-radius: 5px; font-size: 16px; width: 200px; background: #fff; }
@@ -21,6 +34,12 @@ input[type="text"] { padding: 10px; border: 2px solid #ddd; border-radius: 5px; 
 }
 .io-section label.button-like { cursor: pointer; }
 input[type="file"]#xlsxInput { display: none; }
+
+#btnClear { background-color: #d32f2f; }
+
+@media (hover: hover) and (pointer: fine) {
+  #btnClear:hover { background-color: #b71c1c; }
+}
 
 /* disabled 버튼 */
 .search-box button:disabled,


### PR DESCRIPTION
## Summary
- update the main dashboard to use 학번 terminology, persist uploaded datasets, add reset handling, and surface navigation links to analysis tools
- refresh shared styling for the new navigation links and highlight the 초기화 action in red
- add an 전체학생 분석 page that summarises stored scores with totals, averages, subject-level grades, and overall ranking for every student

## Testing
- No automated tests available

------
https://chatgpt.com/codex/tasks/task_b_68d23967b958832a87999de55b74c04e