### PR TITLE
Add privacy reassurance note beneath upload hint

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,6 +31,7 @@
         <a href="data/all_students.html" class="template-link" target="_blank" rel="noopener">전체학생 분석</a>
       </div>
       <div class="hint">먼저 .xlsx 파일을 업로드하세요. (다운로드 버튼은 데이터가 로드되면 활성화됩니다)</div>
+      <div class="hint privacy-note">업로드된 엑셀은 사이트에 저장되지 않으며, 초기화 버튼을 클릭하면 데이터가 사라집니다.</div>
 
       <div class="error-message" id="errorMessage"></div>
       <div class="student-info" id="studentInfo">

--- a/style.css
+++ b/style.css
@@ -97,6 +97,7 @@ canvas { max-height: 250px; }
 .error-message { color: #d32f2f; margin-top: 10px; display: none; }
 
 .hint { color:#777; font-size:14px; margin-top:6px; }
+.hint.privacy-note { color:#c62828; }
 
 .data-table { margin-top: 30px; display: none; }
 table { width: 100%; border-collapse: collapse; margin-top: 20px; }


### PR DESCRIPTION
## Summary
- add a visible privacy reassurance message below the upload guidance
- style the privacy note with a distinct color while keeping existing hint styling

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68d2890971d8832a9749497f45b56e10