### PR TITLE
Add go back button to all students analysis page

### DIFF
--- a/data/all_students.html
+++ b/data/all_students.html
@@ -10,6 +10,31 @@
     .analysis-container h1 { margin-bottom: 10px; }
     .analysis-container .description { color: #555; margin-bottom: 25px; }
 
+    .back-button {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      padding: 8px 14px;
+      margin-bottom: 18px;
+      background-color: #e8f0fe;
+      color: #1a73e8;
+      border-radius: 999px;
+      font-weight: 600;
+      text-decoration: none;
+      box-shadow: 0 1px 3px rgba(26, 39, 86, 0.15);
+      transition: background-color 0.2s ease, color 0.2s ease;
+    }
+
+    .back-button:hover {
+      background-color: #d2e3fc;
+      color: #0c47a1;
+    }
+
+    .back-button .icon {
+      font-size: 18px;
+      line-height: 1;
+    }
+
     .analysis-summary {
       display: flex;
       flex-wrap: wrap;
@@ -174,6 +199,10 @@
 </head>
 <body>
   <div class="container analysis-container">
+    <a href="../index.html" class="back-button" aria-label="메인 화면으로 돌아가기">
+      <span class="icon" aria-hidden="true">←</span>
+      <span>메인으로</span>
+    </a>
     <h1>전체 학생 성적 분석</h1>
     <p class="description">업로드한 엑셀 데이터를 기반으로 학생별 가중치 합계, 가중치 평균, 과목별 등급, 전체 등수를 확인할 수 있습니다.</p>
 


### PR DESCRIPTION
## Summary
- add a styled back button at the top of the 전체 학생 성적 분석 view
- link the button to the 메인 화면 to help users return quickly

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68d2a9ee3b70832a80827fdc856ddb91