### PR TITLE
Fix total student count display in all_students page

### DIFF
--- a/data/all_students.html
+++ b/data/all_students.html
@@ -1303,7 +1303,7 @@
       summary.innerHTML = '';
       if (!students.length) return;
       const items = [
-        { label: '총 학생 수', value: '80명' }
+        { label: '총 학생 수', value: `${students.length}명` }
       ];
 
       items.forEach(({ label, value }) => {


### PR DESCRIPTION
### Motivation
- Replace the hardcoded summary value so the "총 학생 수" card reflects the actual number of parsed students rather than always showing `80명`.

### Description
- In `data/all_students.html` updated the `renderSummary` items entry to use a dynamic value: `{ label: '총 학생 수', value: `${students.length}명` }` instead of the hardcoded `'80명'`.

### Testing
- No automated test suite exists for this repository, so no automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f15899137c8331a67afb3d888db7ce)