### PR TITLE
Use 학번 as unique student identifier and add disambiguation UI for duplicate names

### DIFF
--- a/data/all_students.html
+++ b/data/all_students.html
@@ -476,7 +476,8 @@
     function deriveActiveSubjectIndices(availability) {
       return SUBJECTS.map((_, index) => index).filter(index => {
         return EXAM_STEPS.some(({ key }) => availability?.[key]?.[index]);
-      });
+      })
+      .filter(Boolean);
     }
 
     let termSubjectAvailability = createEmptyTermSubjectAvailability();
@@ -638,8 +639,9 @@
 
     function buildStudentSummaries(dataset) {
       return Object.entries(dataset)
-        .filter(([name]) => !EXCLUDED_STUDENT_NAMES.has(name))
-        .map(([name, info]) => {
+        .map(([studentKey, info]) => {
+          const name = (info && typeof info.name === "string" && info.name.trim()) ? info.name.trim() : String(studentKey ?? "").trim();
+          if (EXCLUDED_STUDENT_NAMES.has(name)) return null;
         const studentId = toFiniteNumber(info.number);
         let studentIdText = '';
         if (info?.number !== undefined && info?.number !== null) {
@@ -674,7 +676,8 @@
           scienceMathAverageGradeText: '-',
           overallRank: 0
         };
-      });
+      })
+      .filter(Boolean);
     }
 
     function computeGradeSlices(total) {

--- a/index.html
+++ b/index.html
@@ -23,6 +23,7 @@
       <div class="search-box">
         <label for="studentName">학생 이름:</label>
         <input type="text" id="studentName" placeholder="엑셀 업로드 후 사용 가능" disabled />
+        <select id="studentSelect" disabled style="display:none;"></select>
         <button id="btnSearch" onclick="searchStudent()" disabled>검색</button>
         <button id="btnClear" onclick="resetApp()">초기화</button>
       </div>
@@ -260,6 +261,9 @@
 
       document.getElementById('btnSearch').disabled = true;
       document.getElementById('btnClear').disabled = false;
+
+      const select = document.getElementById('studentSelect');
+      if (select) { select.innerHTML = ''; select.style.display = 'none'; select.disabled = true; }
 
       const info = document.getElementById('studentInfo');
       info.classList.remove('active');
@@ -581,10 +585,11 @@
           const rows = XLSX.utils.sheet_to_json(ws, { defval: '' });
 
           const newData = {};
-          rows.forEach(row => {
+          rows.forEach((row, index) => {
             const name = String(row['이름'] ?? '').trim();
             if (!name) return;
             const number = extractStudentId(row);
+            const uniqueKey = number || `${name}__${index}`;
 
             const buildTermScores = termKey => {
               const mapping = TERM_SUBJECT_COLUMNS[termKey] || {};
@@ -610,7 +615,8 @@
             const s2 = buildTermScores('semester2');
 
             const hasValid = arr => Array.isArray(arr) && arr.some(value => Number.isFinite(value));
-            newData[name] = {
+            newData[uniqueKey] = {
+              name,
               number: number || '',
               semester1: hasValid(s1) ? s1 : Array(SUBJECTS.length).fill(null),
               semester2: hasValid(s2) ? s2 : Array(SUBJECTS.length).fill(null)
@@ -633,7 +639,7 @@
 
           // 현재 표시 중인 학생이 있으면 새 데이터 기준으로 갱신
           const current = document.getElementById('studentName').value.trim();
-          if (current && studentData[current]) searchStudent();
+          if (current) searchStudent();
 
           evt.target.value = '';
         } catch (err) {
@@ -654,7 +660,7 @@
       document.getElementById('btnClear').disabled = false;
 
       // 힌트 변경
-      document.getElementById('studentName').placeholder = '이름을 입력하세요';
+      document.getElementById('studentName').placeholder = '이름 또는 학번을 입력하세요';
     }
 
     function loadStoredDataset() {
@@ -712,6 +718,44 @@
       enableUIAfterLoad();
     }
 
+
+    function normalizeStudentName(studentKey, student) {
+      if (student && typeof student.name === 'string' && student.name.trim()) return student.name.trim();
+      return String(studentKey ?? '').trim();
+    }
+
+    function getMatchedStudents(keyword) {
+      const trimmed = String(keyword ?? '').trim();
+      if (!trimmed) return [];
+      return Object.entries(studentData)
+        .map(([key, info]) => ({ key, info, name: normalizeStudentName(key, info), number: String(info?.number ?? '').trim() }))
+        .filter(item => item.name === trimmed || item.number === trimmed);
+    }
+
+    function showStudentSelect(matches) {
+      const select = document.getElementById('studentSelect');
+      if (!select) return;
+      select.innerHTML = '';
+      if (!Array.isArray(matches) || matches.length <= 1) {
+        select.style.display = 'none';
+        select.disabled = true;
+        return;
+      }
+      const placeholder = document.createElement('option');
+      placeholder.value = '';
+      placeholder.textContent = '동명이인 선택: 학번을 선택하세요';
+      select.appendChild(placeholder);
+      matches.forEach(({ key, name, number }) => {
+        const option = document.createElement('option');
+        option.value = key;
+        option.textContent = `${name} (${number || '학번 없음'})`;
+        select.appendChild(option);
+      });
+      select.value = '';
+      select.disabled = false;
+      select.style.display = '';
+    }
+
     function searchStudent() {
       if (!dataLoaded) { alert('먼저 데이터를 업로드하세요.'); return; }
 
@@ -722,21 +766,38 @@
       const dataTable = document.getElementById('dataTable');
 
       errorMsg.style.display = 'none'; errorMsg.textContent = '';
-      if (!searchName) { errorMsg.textContent = '학생 이름을 입력해주세요.'; errorMsg.style.display = 'block'; return; }
+      if (!searchName) { errorMsg.textContent = '학생 이름 또는 학번을 입력해주세요.'; errorMsg.style.display = 'block'; return; }
 
-      const student = studentData[searchName];
-      if (!student) {
-        errorMsg.textContent = `'${searchName}' 학생을 찾을 수 없습니다. 정확한 이름을 입력해주세요.`;
+      const matches = getMatchedStudents(searchName);
+      if (!matches.length) {
+        showStudentSelect([]);
+        errorMsg.textContent = `'${searchName}' 학생을 찾을 수 없습니다. 정확한 이름/학번을 입력해주세요.`;
         errorMsg.style.display = 'block';
         studentInfo.classList.remove('active'); chartsSection.style.display = 'none'; dataTable.style.display = 'none';
         return;
       }
 
-      document.getElementById('displayName').textContent = searchName;
+      showStudentSelect(matches);
+      let target = matches[0];
+      if (matches.length > 1) {
+        const selectedKey = document.getElementById('studentSelect')?.value || '';
+        if (!selectedKey) {
+          errorMsg.textContent = `동명이인입니다. 학번을 선택해주세요.`;
+          errorMsg.style.display = 'block';
+          studentInfo.classList.remove('active'); chartsSection.style.display = 'none'; dataTable.style.display = 'none';
+          return;
+        }
+        target = matches.find(item => item.key === selectedKey) || null;
+        if (!target) return;
+      }
+
+      const student = target.info;
+      const displayName = target.name;
+      document.getElementById('displayName').textContent = displayName;
       document.getElementById('displayNumber').textContent = student.number ?? '';
       studentInfo.classList.add('active');
-      createCharts(searchName, student);
-      const hasRows = updateTable(searchName, student);
+      createCharts(target.key, student);
+      const hasRows = updateTable(target.key, student);
       dataTable.style.display = hasRows ? 'block' : 'none';
     }
 
@@ -1059,6 +1120,9 @@
     // Enter로 검색
     document.getElementById('studentName').addEventListener('keypress', function(e) {
       if (e.key === 'Enter') searchStudent();
+    });
+    document.getElementById('studentSelect').addEventListener('change', function() {
+      searchStudent();
     });
 
   </script>


### PR DESCRIPTION
### Motivation
- Prevent uploaded student records from colliding when multiple students share the same 이름 by using 학번 as the unique key for each record. 
- Let users explicitly select the correct student when names are identical and ensure the all-students list shows every record even with duplicate names.

### Description
- Changed XLSX import in `index.html` to key `studentData` by a `uniqueKey` that is `학번` when available, otherwise `name__index`, and preserved `name` as a field on each record (so existing name-based datasets remain readable). (see upload parsing and `newData[uniqueKey]`) 
- Added a `select#studentSelect` dropdown and helper functions (`normalizeStudentName`, `getMatchedStudents`, `showStudentSelect`) to `index.html` so that when multiple records match a search (same name) the user can pick the correct 학번; search now accepts either 이름 or 학번 and placeholder text updated to `이름 또는 학번을 입력하세요`.
- Updated search flow to show the selector on ambiguous matches and require selection before displaying charts/tables; selection change triggers search as well; reset logic clears and hides the selector.
- Updated `data/all_students.html` `buildStudentSummaries` so entries are built from dataset entries (using `info.name` or falling back to the record key) and duplicates are not collapsed, ensuring all students are listed; added a defensive `.filter(Boolean)` after mapping.
- Minor adjustments to subject-availability derivation to avoid falsey entries when building indices.

### Testing
- No automated test suite exists in the repository, so no automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69fac5b17b108331bb47ae31b088a576)