### PR TITLE
Preserve selected 학번 for duplicate-name searches and render chosen student

### DIFF
--- a/index.html
+++ b/index.html
@@ -732,7 +732,7 @@
         .filter(item => item.name === trimmed || item.number === trimmed);
     }
 
-    function showStudentSelect(matches) {
+    function showStudentSelect(matches, selectedKey = '') {
       const select = document.getElementById('studentSelect');
       if (!select) return;
       select.innerHTML = '';
@@ -751,7 +751,11 @@
         option.textContent = `${name} (${number || '학번 없음'})`;
         select.appendChild(option);
       });
-      select.value = '';
+      if (selectedKey && matches.some(item => item.key === selectedKey)) {
+        select.value = selectedKey;
+      } else {
+        select.value = '';
+      }
       select.disabled = false;
       select.style.display = '';
     }
@@ -777,10 +781,10 @@
         return;
       }
 
-      showStudentSelect(matches);
+      const selectedKey = document.getElementById('studentSelect')?.value || '';
+      showStudentSelect(matches, selectedKey);
       let target = matches[0];
       if (matches.length > 1) {
-        const selectedKey = document.getElementById('studentSelect')?.value || '';
         if (!selectedKey) {
           errorMsg.textContent = `동명이인입니다. 학번을 선택해주세요.`;
           errorMsg.style.display = 'block';


### PR DESCRIPTION
### Motivation
- When multiple students share the same `name`, selecting one by `학번` should display that specific student's data on the index page instead of losing the choice when the duplicate dropdown is refreshed.

### Description
- `searchStudent()` now reads `studentSelect.value` before rebuilding options and `showStudentSelect(matches, selectedKey)` was introduced to repopulate the dropdown while preserving a valid selection so the chosen student's charts and table are rendered.

### Testing
- No automated tests exist for this repository, so no automated test was executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69fac7cb68108331a2aabbf971c1f2ee)