### PR TITLE
Fix missing 공통수학1 in all_students subject analysis

### DIFF
--- a/data/all_students.html
+++ b/data/all_students.html
@@ -476,8 +476,7 @@
     function deriveActiveSubjectIndices(availability) {
       return SUBJECTS.map((_, index) => index).filter(index => {
         return EXAM_STEPS.some(({ key }) => availability?.[key]?.[index]);
-      })
-      .filter(Boolean);
+      });
     }
 
     let termSubjectAvailability = createEmptyTermSubjectAvailability();


### PR DESCRIPTION
### Motivation
- The first subject (`공통수학1`) was not shown because `deriveActiveSubjectIndices()` applied `.filter(Boolean)` which removed index `0` (falsy), marking the subject as inactive even when data existed.

### Description
- Removed the erroneous `.filter(Boolean)` in `deriveActiveSubjectIndices()` inside `data/all_students.html` so the function now returns all active subject indices including `0`.

### Testing
- Ran automated checks including `rg -n "deriveActiveSubjectIndices|filter\(Boolean\)" data/all_students.html`, inspected the `git diff` for the change, and completed a commit; these verification steps succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69facc3c374483319043e7f124e16df0)