### PR TITLE
Fix missing subject columns in all_students for legacy dataset format

### DIFF
--- a/data/all_students.html
+++ b/data/all_students.html
@@ -458,8 +458,9 @@
       if (!dataset || typeof dataset !== 'object') return availability;
 
       Object.values(dataset).forEach(info => {
+        const normalizedSemesters = getNormalizedSemesters(info);
         EXAM_STEPS.forEach(({ key }) => {
-          const termScores = info?.[key];
+          const termScores = normalizedSemesters?.[key];
           if (!Array.isArray(termScores)) return;
           termScores.forEach((value, index) => {
             const numeric = toFiniteNumber(value);
@@ -620,6 +621,30 @@
       });
     }
 
+    function parseLegacyFlatTermScores(info, prefix) {
+      if (!info || typeof info !== 'object') {
+        return Array(SUBJECTS.length).fill(null);
+      }
+      return SUBJECTS.map(subjectName => {
+        const key = `${prefix}_${subjectName}`;
+        const numeric = toFiniteNumber(info[key]);
+        return Number.isFinite(numeric) ? numeric : null;
+      });
+    }
+
+    function getNormalizedSemesters(info) {
+      const semester1 = sanitizeTermScores(info?.semester1);
+      const semester2 = sanitizeTermScores(info?.semester2);
+      const hasStructuredScores = semester1.some(Number.isFinite) || semester2.some(Number.isFinite);
+      if (hasStructuredScores) {
+        return { semester1, semester2 };
+      }
+      return {
+        semester1: parseLegacyFlatTermScores(info, 's1'),
+        semester2: parseLegacyFlatTermScores(info, 's2')
+      };
+    }
+
     function calculateSubjectAverage(student, index) {
       if (!isSubjectActive(index)) return null;
       const terms = [student.semester1, student.semester2];
@@ -649,10 +674,7 @@
         if (!studentIdText && Number.isFinite(studentId)) {
           studentIdText = String(studentId);
         }
-        const normalizedSemesters = {
-          semester1: sanitizeTermScores(info.semester1),
-          semester2: sanitizeTermScores(info.semester2)
-        };
+        const normalizedSemesters = getNormalizedSemesters(info);
         const subjectAverages = SUBJECTS.map((_, idx) => calculateSubjectAverage(normalizedSemesters, idx));
         const validScores = subjectAverages.filter(value => Number.isFinite(value));
         const totalScore = validScores.reduce((sum, value) => sum + value, 0);


### PR DESCRIPTION
### Motivation
- Legacy datasets sometimes store scores as flat keys like `s1_공통수학1` / `s2_공통수학1` instead of `semester1`/`semester2` arrays, causing valid subjects (e.g. index 0 `공통수학1`) to be treated as unavailable and hidden. 
- The goal is to ensure subject availability detection and student summary calculations use the same normalized input so all non-null subjects are shown.

### Description
- Added `parseLegacyFlatTermScores` and `getNormalizedSemesters` helpers in `data/all_students.html` to normalize either structured `semester1`/`semester2` arrays or legacy `s1_*/s2_*` flat keys into consistent semester arrays. 
- Updated `computeTermSubjectAvailability` to use the normalized semester arrays so active subjects are detected from legacy flat keys. 
- Updated `buildStudentSummaries` to use `getNormalizedSemesters` so average calculation and rendering use the same normalized data source.

### Testing
- Ran repository checks and change workflow commands: `git status --short`, `git diff -- data/all_students.html`, `git add` and `git commit`, and `make_pr`, and all commands completed successfully. 
- No automated unit test suite exists for this project, so behavior was validated by ensuring the availability detection and summary generation code paths were changed to share the normalized input and by inspecting the produced diff.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69face5978708331ae581f75646ebeb7)