### PR TITLE
Add dummy sample value for S1_통합사회1 in template download

### DIFF
--- a/index.html
+++ b/index.html
@@ -542,7 +542,7 @@
 
       const sampleStudent = ['홍길동','101'];
       const sampleScoresByTerm = {
-        semester1: [95, 94, 93, 92, 91, 96, 95, 94],
+        semester1: [95, 94, 93, 92, 91, 96, 95, 94, 94],
         semester2: [94, 95, 93, 92, 91, 90, 89, 88, 87, 96, 95, 94]
       };
       EXAM_STEPS.forEach(({ key }) => {


### PR DESCRIPTION
### Motivation
- Ensure the Excel template generated by `downloadTemplate` contains a sample value for the `S1_통합사회1` column so sample rows align with all semester 1 subjects.

### Description
- Updated `index.html` to add a dummy value `94` to `sampleScoresByTerm.semester1` inside the `downloadTemplate` function so the sample array length matches `TERM_SUBJECTS` for semester 1.

### Testing
- Ran `rg -n "양식 다운로드|S1_통합사회1|통합사회1" index.html` and inspected the changed lines with `nl -ba index.html | sed -n '538,550p'` to verify the `semester1` array now contains nine values, and the check succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a041c47973c8331a37a6c344a352ba4)