### PR TITLE
Normalize legacy term score layouts and handle shifted subject columns

### DIFF
--- a/data/all_students.html
+++ b/data/all_students.html
@@ -614,11 +614,25 @@
       if (!Array.isArray(term)) {
         return Array(SUBJECTS.length).fill(null);
       }
-      return SUBJECTS.map((_, index) => {
+      const sanitized = SUBJECTS.map((_, index) => {
         if (index >= term.length) return null;
         const numeric = toFiniteNumber(term[index]);
         return Number.isFinite(numeric) ? numeric : null;
       });
+      const hasLegacyShift =
+        Number.isFinite(sanitized[5]) &&
+        Number.isFinite(sanitized[6]) &&
+        Number.isFinite(sanitized[7]) &&
+        !Number.isFinite(sanitized[8]);
+      if (!hasLegacyShift) return sanitized;
+      const shifted = Array(SUBJECTS.length).fill(null);
+      for (let i = 0; i <= 4; i += 1) shifted[i] = sanitized[i];
+      shifted[5] = null;
+      shifted[6] = sanitized[5];
+      shifted[7] = sanitized[6];
+      shifted[8] = sanitized[7];
+      for (let i = 9; i < SUBJECTS.length; i += 1) shifted[i] = sanitized[i];
+      return shifted;
     }
 
     function parseLegacyFlatTermScores(info, prefix) {

--- a/index.html
+++ b/index.html
@@ -135,6 +135,7 @@
     ];
     const SUBJECT_COUNT = SUBJECTS.length;
     const COLUMN_KEY_ALIASES = {
+      'S1_정보과학': ['S2_정보과학'],
       'S2_통합사회2': ['S2_통합사회']
     };
 
@@ -709,7 +710,45 @@
       return Number.isFinite(numeric) ? numeric : null;
     }
 
-    const storedDataset = loadStoredDataset();
+    function normalizeLegacyTermLayout(termScores, termKey) {
+      if (!Array.isArray(termScores)) return termScores;
+      if (termKey !== 'semester1') return termScores;
+      const normalized = SUBJECTS.map((_, index) => {
+        const numeric = toNum(termScores[index]);
+        return Number.isFinite(numeric) ? numeric : null;
+      });
+      const hasLegacyShift =
+        Number.isFinite(normalized[5]) &&
+        Number.isFinite(normalized[6]) &&
+        Number.isFinite(normalized[7]) &&
+        !Number.isFinite(normalized[8]);
+      if (!hasLegacyShift) return normalized;
+      const shifted = Array(SUBJECTS.length).fill(null);
+      for (let i = 0; i <= 4; i += 1) shifted[i] = normalized[i];
+      shifted[5] = null; // 정보과학(구버전 파일에는 없음)
+      shifted[6] = normalized[5];
+      shifted[7] = normalized[6];
+      shifted[8] = normalized[7];
+      for (let i = 9; i < SUBJECTS.length; i += 1) shifted[i] = normalized[i];
+      return shifted;
+    }
+
+    function normalizeDatasetLayout(dataset) {
+      if (!dataset || typeof dataset !== 'object') return dataset;
+      const normalizedDataset = {};
+      Object.entries(dataset).forEach(([key, info]) => {
+        const semester1 = normalizeLegacyTermLayout(info?.semester1, 'semester1');
+        const semester2 = normalizeLegacyTermLayout(info?.semester2, 'semester2');
+        normalizedDataset[key] = {
+          ...info,
+          semester1: Array.isArray(semester1) ? semester1 : Array(SUBJECTS.length).fill(null),
+          semester2: Array.isArray(semester2) ? semester2 : Array(SUBJECTS.length).fill(null)
+        };
+      });
+      return normalizedDataset;
+    }
+
+    const storedDataset = normalizeDatasetLayout(loadStoredDataset());
     if (storedDataset && Object.keys(storedDataset).length > 0) {
       updateSubjectAvailabilityFromDataset(storedDataset);
       studentData = storedDataset;


### PR DESCRIPTION
### Motivation
- Handle legacy datasets where semester arrays are missing `정보과학`, causing subject-score indices to be shifted and resulting in incorrect score mapping.
- Ensure column aliasing covers legacy column name differences for consistent lookups.

### Description
- Updated `sanitizeTermScores` to detect a legacy-shift pattern (indices 5–7 populated and index 8 empty) and insert a `null` placeholder at the `정보과학` position while shifting subsequent scores into their correct indices.
- Added `normalizeLegacyTermLayout` and `normalizeDatasetLayout` to `index.html` and applied these to the loaded dataset via `storedDataset = normalizeDatasetLayout(loadStoredDataset())` so legacy layouts are normalized at load time.
- Introduced a column alias mapping in `COLUMN_KEY_ALIASES` to handle alternate legacy column keys for subject lookup.
- Kept/clarified numeric parsing helpers (`toFiniteNumber`/`toNum`) and ensured parsed values are converted to finite numbers or `null` consistently.

### Testing
- Ran the application load flow with legacy-formatted datasets to verify semester arrays are normalized and subject scores align correctly (existing automated checks and build steps passed locally).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0576c6ee948331b6d1e2c4bc6ac78d)