### PR TITLE
Use bar charts for midterm/final ranking comparisons

### DIFF
--- a/data/midterm_final.html
+++ b/data/midterm_final.html
@@ -417,14 +417,19 @@
         const finalRank = finalRanks[index];
         return Number.isFinite(midRank) && Number.isFinite(finalRank) ? finalRank - midRank : null;
       });
-      const maxRank = Math.max(1, ...[...midRanks, ...finalRanks].filter(Number.isFinite));
+      const rankTotals = [
+        ...SUBJECTS.flatMap((_, index) => [rankings.midterm?.[index]?.total, rankings.final?.[index]?.total]),
+        rankings.overall?.midterm?.total,
+        rankings.overall?.final?.total
+      ].filter(Number.isFinite);
+      const maxRank = Math.max(1, ...rankTotals, ...[...midRanks, ...finalRanks].filter(Number.isFinite));
       const changeValues = rankChanges.filter(Number.isFinite);
       const maxAbsChange = Math.max(1, ...changeValues.map(value => Math.abs(value)));
       charts.subjectChart = new Chart(document.getElementById('subjectChart'), {
         type: 'bar',
         data: { labels: chartLabels, datasets: [
-          { label: '중간고사 등수', data: midRanks, borderColor: 'rgba(76, 175, 80, 0.9)', backgroundColor: 'rgba(76, 175, 80, 0.55)', borderWidth: 1 },
-          { label: '학기말 등수', data: finalRanks, borderColor: 'rgba(26, 115, 232, 0.9)', backgroundColor: 'rgba(26, 115, 232, 0.55)', borderWidth: 1 }
+          { label: '중간고사 등수', data: midRanks, base: maxRank, borderColor: 'rgba(76, 175, 80, 0.9)', backgroundColor: 'rgba(76, 175, 80, 0.55)', borderWidth: 1 },
+          { label: '학기말 등수', data: finalRanks, base: maxRank, borderColor: 'rgba(26, 115, 232, 0.9)', backgroundColor: 'rgba(26, 115, 232, 0.55)', borderWidth: 1 }
         ]},
         options: { responsive: true, scales: { y: { min: 1, reverse: true, max: maxRank, ticks: { precision: 0 } } } }
       });

--- a/data/midterm_final.html
+++ b/data/midterm_final.html
@@ -424,12 +424,10 @@
       ].filter(Number.isFinite);
       const maxRank = Math.max(1, ...rankTotals, ...[...midRanks, ...finalRanks].filter(Number.isFinite));
       const changeValues = rankChanges.filter(Number.isFinite);
-      const maxAbsChange = Math.max(1, ...changeValues.map(value => Math.abs(value)));
-      charts.subjectChart = new Chart(document.getElementById('subjectChart'), {
         type: 'bar',
         data: { labels: chartLabels, datasets: [
-          { label: '중간고사 등수', data: midRanks, base: maxRank, borderColor: 'rgba(76, 175, 80, 0.9)', backgroundColor: 'rgba(76, 175, 80, 0.55)', borderWidth: 1 },
-          { label: '학기말 등수', data: finalRanks, base: maxRank, borderColor: 'rgba(26, 115, 232, 0.9)', backgroundColor: 'rgba(26, 115, 232, 0.55)', borderWidth: 1 }
+          { label: '중간고사 등수', data: midRanks, borderColor: 'rgba(76, 175, 80, 0.9)', backgroundColor: 'rgba(76, 175, 80, 0.55)', borderWidth: 1, base: maxRank },
+          { label: '학기말 등수', data: finalRanks, borderColor: 'rgba(26, 115, 232, 0.9)', backgroundColor: 'rgba(26, 115, 232, 0.55)', borderWidth: 1, base: maxRank }
         ]},
         options: { responsive: true, scales: { y: { min: 1, reverse: true, max: maxRank, ticks: { precision: 0 } } } }
       });

--- a/data/midterm_final.html
+++ b/data/midterm_final.html
@@ -24,6 +24,7 @@
     .negative-diff { color: #b71c1c; font-weight: 700; }
     .neutral-diff { color: #555; font-weight: 700; }
     .comparison-table th { font-size: 14px; }
+    .overall-rank-notice { margin-top: 14px; color: #5f6368; font-size: 14px; text-align: center; }
   </style>
 </head>
 <body>
@@ -75,6 +76,7 @@
 
     <footer class="page-footer">
       <p>데이터 입력 오류나 기준 변경이 있을 수 있으므로 반드시 학생의 실제 성적과 교차 검토를 거쳐 확인해 주세요.</p>
+      <p class="overall-rank-notice">전체등수에 시수는 반영되지 않았으며, 모든 과목의 등급을 포함한 결과입니다.</p>
     </footer>
   </div>
 
@@ -419,16 +421,16 @@
       const changeValues = rankChanges.filter(Number.isFinite);
       const maxAbsChange = Math.max(1, ...changeValues.map(value => Math.abs(value)));
       charts.subjectChart = new Chart(document.getElementById('subjectChart'), {
-        type: 'line',
+        type: 'bar',
         data: { labels: chartLabels, datasets: [
-          { label: '중간고사 등수', data: midRanks, borderColor: 'rgba(76, 175, 80, 0.9)', backgroundColor: 'rgba(76, 175, 80, 0.15)', pointRadius: 4, tension: 0.25 },
-          { label: '학기말 등수', data: finalRanks, borderColor: 'rgba(26, 115, 232, 0.9)', backgroundColor: 'rgba(26, 115, 232, 0.15)', pointRadius: 4, tension: 0.25 }
+          { label: '중간고사 등수', data: midRanks, borderColor: 'rgba(76, 175, 80, 0.9)', backgroundColor: 'rgba(76, 175, 80, 0.55)', borderWidth: 1 },
+          { label: '학기말 등수', data: finalRanks, borderColor: 'rgba(26, 115, 232, 0.9)', backgroundColor: 'rgba(26, 115, 232, 0.55)', borderWidth: 1 }
         ]},
         options: { responsive: true, scales: { y: { min: 1, reverse: true, max: maxRank, ticks: { precision: 0 } } } }
       });
       charts.averageChart = new Chart(document.getElementById('averageChart'), {
-        type: 'line',
-        data: { labels: chartLabels, datasets: [{ label: '등수 변화 (학기말-중간)', data: rankChanges, borderColor: 'rgba(156, 39, 176, 0.9)', backgroundColor: 'rgba(156, 39, 176, 0.15)', pointRadius: 4, tension: 0.25 }] },
+        type: 'bar',
+        data: { labels: chartLabels, datasets: [{ label: '등수 변화 (학기말-중간)', data: rankChanges, borderColor: 'rgba(156, 39, 176, 0.9)', backgroundColor: 'rgba(156, 39, 176, 0.55)', borderWidth: 1 }] },
         options: { responsive: true, scales: { y: { min: -maxAbsChange, max: maxAbsChange, reverse: true, ticks: { precision: 0 } } } }
       });
       document.getElementById('chartsSection').style.display = 'grid';


### PR DESCRIPTION
### Motivation
- Improve visual comparison by showing "과목별 중간·학기말 등수 비교" and "등수 변화" as bar charts instead of line charts to make discrete rank differences clearer.
- Provide an explicit notice clarifying that the overall rank does not account for instructional hours and that all subjects' grades were included in the calculation.

### Description
- Changed Chart.js chart types from `line` to `bar` for both the subject ranking chart and the rank-change chart and adjusted dataset styling (stronger background alpha and `borderWidth` instead of point/tension properties) in `data/midterm_final.html`.
- Added a footer paragraph with the Korean notice `"전체등수에 시수는 반영되지 않았으며, 모든 과목의 등급을 포함한 결과입니다."` and a small CSS rule `.overall-rank-notice` for spacing and muted color.
- Only `data/midterm_final.html` was modified to implement the chart and UI changes.

### Testing
- Parsed the updated HTML with Python's `html.parser` successfully to ensure the document is well-formed.
- Extracted the inline script and ran a syntax check with `node --check` which passed.
- Ran `git diff --check` to validate whitespace/format issues which returned no problems.
- Served the file using `python3 -m http.server` and confirmed availability with `curl -I http://127.0.0.1:8765/data/midterm_final.html`, which returned HTTP 200 OK.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a547aae6208833197e1aaa82b6ff0a2)