### PR TITLE
Fix midterm_final chart syntax error

### DIFF
--- a/data/midterm_final.html
+++ b/data/midterm_final.html
@@ -424,6 +424,8 @@
       ].filter(Number.isFinite);
       const maxRank = Math.max(1, ...rankTotals, ...[...midRanks, ...finalRanks].filter(Number.isFinite));
       const changeValues = rankChanges.filter(Number.isFinite);
+      const maxAbsChange = Math.max(1, ...changeValues.map(value => Math.abs(value)));
+      charts.subjectChart = new Chart(document.getElementById('subjectChart'), {
         type: 'bar',
         data: { labels: chartLabels, datasets: [
           { label: '중간고사 등수', data: midRanks, borderColor: 'rgba(76, 175, 80, 0.9)', backgroundColor: 'rgba(76, 175, 80, 0.55)', borderWidth: 1, base: maxRank },


### PR DESCRIPTION
### Motivation
- Fix a JavaScript parse/runtime error in `data/midterm_final.html` that caused an `Unexpected token ':'` and prevented functions such as `uploadXLSX` and `resetApp` from being defined and executed.

### Description
- Restore the missing `charts.subjectChart = new Chart(...)` wrapper around the subject comparison chart and add a `maxAbsChange` calculation before it is used for the rank-change chart y-axis.

### Testing
- Ran `node --check /tmp/midterm_final_script.js` and `git diff --check`, and both checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a54825b0de48331b401aea5ccc4bab4)