### PR TITLE
Color rank-change bars by direction

### DIFF
--- a/data/midterm_final.html
+++ b/data/midterm_final.html
@@ -425,6 +425,14 @@
       const maxRank = Math.max(1, ...rankTotals, ...[...midRanks, ...finalRanks].filter(Number.isFinite));
       const changeValues = rankChanges.filter(Number.isFinite);
       const maxAbsChange = Math.max(1, ...changeValues.map(value => Math.abs(value)));
+      const rankChangeBarColors = rankChanges.map(value => {
+        if (!Number.isFinite(value) || value === 0) return 'rgba(95, 99, 104, 0.55)';
+        return value < 0 ? 'rgba(244, 67, 54, 0.55)' : 'rgba(26, 115, 232, 0.55)';
+      });
+      const rankChangeBorderColors = rankChanges.map(value => {
+        if (!Number.isFinite(value) || value === 0) return 'rgba(95, 99, 104, 0.9)';
+        return value < 0 ? 'rgba(244, 67, 54, 0.9)' : 'rgba(26, 115, 232, 0.9)';
+      });
       charts.subjectChart = new Chart(document.getElementById('subjectChart'), {
         type: 'bar',
         data: { labels: chartLabels, datasets: [
@@ -435,7 +443,7 @@
       });
       charts.averageChart = new Chart(document.getElementById('averageChart'), {
         type: 'bar',
-        data: { labels: chartLabels, datasets: [{ label: '등수 변화 (학기말-중간)', data: rankChanges, borderColor: 'rgba(156, 39, 176, 0.9)', backgroundColor: 'rgba(156, 39, 176, 0.55)', borderWidth: 1 }] },
+        data: { labels: chartLabels, datasets: [{ label: '등수 변화 (학기말-중간)', data: rankChanges, borderColor: rankChangeBorderColors, backgroundColor: rankChangeBarColors, borderWidth: 1 }] },
         options: { responsive: true, scales: { y: { min: -maxAbsChange, max: maxAbsChange, reverse: true, ticks: { precision: 0 } } } }
       });
       document.getElementById('chartsSection').style.display = 'grid';


### PR DESCRIPTION
### Motivation
- Make the `등수 변화` chart more informative by visually distinguishing rank improvements from declines using color (red for negative changes, blue for positive changes). 

### Description
- Update `data/midterm_final.html` to compute `rankChangeBarColors` and `rankChangeBorderColors` arrays by mapping each `rankChanges` value to a color. 
- Use red (`rgba(244, 67, 54, ...)`) for negative values, blue (`rgba(26, 115, 232, ...)`) for positive values, and neutral gray for zero or non-finite values. 
- Apply these per-value `backgroundColor` and `borderColor` arrays to the `등수 변화 (학기말-중간)` Chart.js dataset.

### Testing
- Ran `node --check` on the extracted `<script>` contents of `data/midterm_final.html` and it completed without syntax errors. 
- Ran `git diff --check` and no whitespace or diff errors were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a548470e8488331805abfcb175d373b)