### PR TITLE
Update midterm_final chart directions and labels

### DIFF
--- a/data/midterm_final.html
+++ b/data/midterm_final.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>중간고사 학기말 성적비교 1.0</title>
+  <title>중간고사 학기말 성적비교 1.2</title>
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/xlsx@0.18.5/dist/xlsx.full.min.js"></script>
   <link rel="stylesheet" href="../style.css" />
@@ -31,7 +31,7 @@
   <div class="container">
     <a class="back-button" href="../index.html"><span aria-hidden="true">←</span> 학생별 성적 추이로 돌아가기</a>
     <header class="page-header">
-      <h1>중간고사 학기말 성적비교 1.0</h1>
+      <h1>중간고사 학기말 성적비교 1.2</h1>
     </header>
     <p class="comparison-description">중간고사와 학기말 성적을 한 파일로 업로드하여 학생별 과목 등수 변화와 등급 변화를 비교합니다.</p>
 
@@ -427,12 +427,29 @@
       const maxAbsChange = Math.max(1, ...changeValues.map(value => Math.abs(value)));
       const rankChangeBarColors = rankChanges.map(value => {
         if (!Number.isFinite(value) || value === 0) return 'rgba(95, 99, 104, 0.55)';
-        return value < 0 ? 'rgba(244, 67, 54, 0.55)' : 'rgba(26, 115, 232, 0.55)';
+        return value > 0 ? 'rgba(244, 67, 54, 0.55)' : 'rgba(26, 115, 232, 0.55)';
       });
       const rankChangeBorderColors = rankChanges.map(value => {
         if (!Number.isFinite(value) || value === 0) return 'rgba(95, 99, 104, 0.9)';
-        return value < 0 ? 'rgba(244, 67, 54, 0.9)' : 'rgba(26, 115, 232, 0.9)';
+        return value > 0 ? 'rgba(244, 67, 54, 0.9)' : 'rgba(26, 115, 232, 0.9)';
       });
+      const rankChangeDirectionLabels = {
+        id: 'rankChangeDirectionLabels',
+        afterDraw(chart) {
+          const yScale = chart.scales?.y;
+          const { ctx, chartArea } = chart;
+          if (!yScale || !chartArea) return;
+          ctx.save();
+          ctx.fillStyle = '#1a237e';
+          ctx.font = '700 13px sans-serif';
+          ctx.textAlign = 'right';
+          ctx.textBaseline = 'top';
+          ctx.fillText('상승', yScale.left - 8, chartArea.top + 2);
+          ctx.textBaseline = 'bottom';
+          ctx.fillText('하락', yScale.left - 8, chartArea.bottom - 2);
+          ctx.restore();
+        }
+      };
       charts.subjectChart = new Chart(document.getElementById('subjectChart'), {
         type: 'bar',
         data: { labels: chartLabels, datasets: [
@@ -444,7 +461,7 @@
       charts.averageChart = new Chart(document.getElementById('averageChart'), {
         type: 'bar',
         data: { labels: chartLabels, datasets: [{ label: '등수 변화 (학기말-중간)', data: rankChanges, borderColor: rankChangeBorderColors, backgroundColor: rankChangeBarColors, borderWidth: 1 }] },
-        options: { responsive: true, scales: { y: { min: -maxAbsChange, max: maxAbsChange, reverse: true, ticks: { precision: 0 } } } }
+        options: { responsive: true, layout: { padding: { left: 34 } }, scales: { y: { min: -maxAbsChange, max: maxAbsChange, reverse: true, ticks: { precision: 0 } } } }, plugins: [rankChangeDirectionLabels]
       });
       document.getElementById('chartsSection').style.display = 'grid';
     }


### PR DESCRIPTION
### Motivation
- Improve clarity of the 등수 변화 chart by labeling the y-axis endpoints with `상승` and `하락` and make the bar direction/color semantics match the intended meaning (positive change = 하락, negative change = 상승). 
- Bump the page title to reflect the updated behavior and version as `중간고사 학기말 성적비교 1.2`.

### Description
- Updated the document `<title>` and visible header `h1` to `중간고사 학기말 성적비교 1.2` in `data/midterm_final.html`.
- Reversed the rank-change color mapping so `value > 0` uses red (`rgba(244, 67, 54, ...)`) and `value < 0` uses blue (`rgba(26, 115, 232, ...)`) to match the requested semantics.
- Added a small Chart.js plugin `rankChangeDirectionLabels` that draws `상승` at the top and `하락` at the bottom of the rank-change chart, and registered it on the chart; also added left padding so the labels do not overlap the chart.
- Kept the chart `y` axis reversed so positive values visually extend downward toward `하락` and negative values extend upward toward `상승` for consistency with the requested behavior.

### Testing
- Ran a content assertion script (`python3` checks) that verifies presence of `중간고사 학기말 성적비교 1.2`, the plugin identifier `rankChangeDirectionLabels`, and the updated color conditional (`value > 0 ? 'rgba(244, 67, 54`), which all passed.
- Ran `git diff --check` which reported no whitespace or diff issues and succeeded.
- Attempted to run headless/browser-based rendering verification but Playwright/browser binaries were not available in the environment, so no automated render/screenshot tests were executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a54875103e88331a0ab269523c0f90f)